### PR TITLE
fix: ignoring .git path for fd command

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,7 @@ export DEBUG=${INPUT_DEBUG:-}
 export EXCLUDE=${INPUT_EXCLUDE:-}
 
 # Command line parameters for fd ("exclude" and "search_paths" parameters are ignored if this is set)
-export FD_CMD_PARAMS="${INPUT_FD_CMD_PARAMS:- . -0 --extension md --type f --hidden --no-ignore}"
+export FD_CMD_PARAMS="${INPUT_FD_CMD_PARAMS:- . -0 --extension md --type f --hidden --no-ignore --exclude .git/}"
 
 # Files or paths which will be linted
 export SEARCH_PATHS=${INPUT_SEARCH_PATHS:-}


### PR DESCRIPTION
We just got a "bug" when someone creates a branch called `something.md`. When this happens, `fd` accept the `.git/refs/head/something.md` as a `.md` file and `markdownlint-cli` try to lint them, this is a real example:

<img width="954" alt="image" src="https://user-images.githubusercontent.com/968339/161071204-29dc6ab0-53c9-4f5b-bbdf-d95c63fa7501.png">

adding a `--exclude .git/` to ignore an unwanted path.