### PR TITLE
fix: authenticate rolling version tag push in release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Tag major and minor versions
         if: ${{ steps.release.outputs.release_created }}
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MAJOR: ${{ steps.release.outputs.major }}
           MINOR: ${{ steps.release.outputs.minor }}
         run: |
@@ -52,6 +53,12 @@ jobs:
           git tag -f "v${MAJOR}" "${SHA}"
           git tag -f "v${MAJOR}.${MINOR}" "${SHA}"
 
-          # Push tags to remote
-          git push --force origin "v${MAJOR}"
-          git push --force origin "v${MAJOR}.${MINOR}"
+          # Push tags to remote.
+          # The checkout step uses persist-credentials: false, so no git
+          # credentials are stored. Authenticate the push explicitly with the
+          # workflow token via the remote URL. Disable xtrace first so the
+          # token is never written to the logs.
+          set +x
+          REMOTE_URL="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push --force "${REMOTE_URL}" "v${MAJOR}"
+          git push --force "${REMOTE_URL}" "v${MAJOR}.${MINOR}"

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,2 +1,2 @@
 # Tokenized git remote used to push tags in release-please.yml
-x-access-token
+https://x-access-token:.*@github\.com

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,2 @@
+# Tokenized git remote used to push tags in release-please.yml
+x-access-token

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,4 +1,1 @@
-# Tokenized git remote used to push tags in release-please.yml.
-# Lychee parses the "https://x-access-token:${GH_TOKEN}@github.com/..." string
-# and extracts it as "https://x-access-token/", so match that host.
 https://x-access-token/

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,2 +1,4 @@
-# Tokenized git remote used to push tags in release-please.yml
-https://x-access-token:.*@github\.com
+# Tokenized git remote used to push tags in release-please.yml.
+# Lychee parses the "https://x-access-token:${GH_TOKEN}@github.com/..." string
+# and extracts it as "https://x-access-token/", so match that host.
+https://x-access-token/


### PR DESCRIPTION
## Problem

After a release, the `Tag major and minor versions` step in `release-please.yml` force-updates the rolling `v<major>` and `v<major>.<minor>` tags. The checkout immediately before it uses `persist-credentials: false`, so no git credentials are stored and the pushes fail:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

The exact version tag (created via the release API by release-please) is unaffected, but the rolling tags are left pointing at the **previous** release — so consumers pinning to `@v<major>` get stale code. This was observed on the most recent release.

## Fix

Authenticate the `git push` explicitly with the built-in `GITHUB_TOKEN` via the remote URL, while keeping `persist-credentials: false`. `xtrace` is disabled before constructing the URL so the token is never printed to the logs (it is also auto-masked by Actions).

## Notes

- No change to permissions; the workflow already grants `contents: write`.
- Validated with `actionlint`.
- The rolling tags for the current release have already been corrected manually; this prevents the issue on future releases.